### PR TITLE
Set workdir in order to load server_index.html

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM java:openjdk-7-jdk
 MAINTAINER Daniel Davison <sircapsalot@gmail.com>
 
 #  Version
-ENV   SOAPUI_VERSION  5.2.1
+ENV   SOAPUI_VERSION  5.3.0
 
 COPY entry_point.sh /opt/bin/entry_point.sh
 COPY server.py /opt/bin/server.py
@@ -18,6 +18,9 @@ RUN mkdir -p /opt &&\
     curl  http://cdn01.downloads.smartbear.com/soapui/${SOAPUI_VERSION}/SoapUI-${SOAPUI_VERSION}-linux-bin.tar.gz \
     | gunzip -c - | tar -xf - -C /opt && \
     ln -s /opt/SoapUI-${SOAPUI_VERSION} /opt/SoapUI
+
+# Set working directory
+WORKDIR /opt/bin
 
 # Set environment
 ENV PATH ${PATH}:/opt/SoapUI/bin


### PR DESCRIPTION
When spinning up the container, server_index.html did not load becuase server.py is looking for the file within it's relative path.  Setting WORKDIR to the correct path solves this.  Also updated the version to 5.3.0