### PR TITLE
Allow running tests with a global properties file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ $ curl --form "project=@/path/to/soapui-project.xml" \
        http://localhost:3000
 ```
 
+Optionally, you can send a global properties configuration file.
+
+```sh
+$ curl --form "project=@/path/to/soapui-project.xml" \
+       --form "suite=TestSuite" \
+       --form "properties=@dev.properties" \
+       http://localhost:3000
+```
+
+
 Develop/Test
 ============
 

--- a/server.py
+++ b/server.py
@@ -35,6 +35,7 @@ class S(BaseHTTPRequestHandler):
 
         suite = postvars.get('suite')
         xml = postvars.get('project')
+        properties = postvars.get('properties')
 
         if not suite:
             self.send_response(551, message='No Suite')
@@ -52,12 +53,22 @@ class S(BaseHTTPRequestHandler):
         else:
             xml = xml[0]
 
+        arguments = ['/opt/SoapUI/bin/testrunner.sh',
+                   '-s"%s"' % suite,
+                   '/tmp/soapui-project.xml'];
+
+        if properties:
+            properties = properties[0]
+            f = open('/tmp/global.properties', 'w')
+            print(properties, file=f)
+            f.close()
+            arguments.append('-Dsoapui.properties=/tmp/global.properties')
+
         f = open('/tmp/soapui-project.xml', 'w')
         print(xml, file=f)
         f.close()
-        p = Popen(['/opt/SoapUI/bin/testrunner.sh',
-                   '-s"%s"' % suite,
-                   '/tmp/soapui-project.xml'], stdin=PIPE, stdout=PIPE, stderr=PIPE, bufsize=-1)
+
+        p = Popen(arguments, stdin=PIPE, stdout=PIPE, stderr=PIPE, bufsize=-1)
         try:
             output, error = p.communicate()
 


### PR DESCRIPTION
We needed to run our SoapUI tests with a global properties file for environment specific configurations like dev, qa ... This PR adds this feature so that an optional properties file can be sent when running the tests.