### PR TITLE
Added support for parsing native command line options to testrunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,16 @@ forwards the `3000` port to the container.
 
 ```sh
 $ curl --form "project=@/path/to/soapui-project.xml" \
-       --form "suite=TestSuite" \
        http://localhost:3000
 ```
 
-Optionally, you can send a global properties configuration file.
+Optionally, you can specify the test suite, send a global properties configuration file and send testrunner options.
 
 ```sh
 $ curl --form "project=@/path/to/soapui-project.xml" \
        --form "suite=TestSuite" \
        --form "properties=@dev.properties" \
+       --form "option=-r" \
        http://localhost:3000
 ```
 
@@ -53,6 +53,5 @@ as well as an HTTP status code to determine the result of the test run.
 | -----|---------|------------ |
 | **200**  | OK      | All SoapUI Tests ran successfully and passed |
 | **550**  | Test Failure(s) | You have failures in the SoapUI Test suite / cases. You can check the content of the request to determine what failed |
-| **551**  | No Suite | You did not specify the `suite` POST parameter with the name of the suite you wanted to run |
 | **552**  | No SoapUI Project | You did not specify the `project` POST parameter with the proper SoapUI XML data.  *Remember*: This needs to be the actual file itself sent as multipart/form-data. E.g: `curl -F "data=@the-soapui-project.xml"` |
 | **500**  | Internal Server Error | An exception occured while running the SoapUI Tests |

--- a/server.py
+++ b/server.py
@@ -36,15 +36,8 @@ class S(BaseHTTPRequestHandler):
         suite = postvars.get('suite')
         xml = postvars.get('project')
         properties = postvars.get('properties')
-
-        if not suite:
-            self.send_response(551, message='No Suite')
-            self.end_headers()
-            self.wfile.write('you need to specify a suite!')
-            return
-        else:
-            suite = suite[0]
-
+        option = postvars.get('option')
+        
         if not xml:
             self.send_response(552, message='No SoapUI Project')
             self.end_headers()
@@ -53,9 +46,19 @@ class S(BaseHTTPRequestHandler):
         else:
             xml = xml[0]
 
-        arguments = ['/opt/SoapUI/bin/testrunner.sh',
-                     '-s"%s"' % suite,
-                     '/tmp/soapui-project.xml']
+        f = open('/tmp/soapui-project.xml', 'w')
+        print(xml, file=f)
+        f.close()
+        
+        arguments = ['/opt/SoapUI/bin/testrunner.sh']
+
+        if suite: 
+            arguments.append('-s"%s"' % suite[0])
+
+        if option:
+            for op in option:
+                for line in op.splitlines():
+                    arguments.append('%s' % line)
 
         if properties:
             properties = properties[0]
@@ -64,9 +67,7 @@ class S(BaseHTTPRequestHandler):
             f.close()
             arguments.append('-Dsoapui.properties=/tmp/global.properties')
 
-        f = open('/tmp/soapui-project.xml', 'w')
-        print(xml, file=f)
-        f.close()
+        arguments.append('/tmp/soapui-project.xml')
 
         p = Popen(arguments, stdin=PIPE, stdout=PIPE, stderr=PIPE, bufsize=-1)
         try:

--- a/server_index.html
+++ b/server_index.html
@@ -52,13 +52,17 @@
   <pre class="code">
     $ curl --form "project=@/path/to/soapui-project.xml" \
            --form "suite=TestSuite" \
+           --form "properties=@pathToGlobalPropertiesFile" \
+           --form "option=-r" \
            <span class="location">this URL</span>
   </pre>
 
   <strong>Use a REST client to POST to <span class="location"></span> with these variables</strong>
   <ul>
-    <li><strong>project</strong> <em>- the actual content of the SoapUI project xml</em></li>
-    <li><strong>suite</strong> <em>- the suite to run (usually will be TestSuite if left unchanged from SoapUI)</em></li>
+    <li><strong>project</strong> <em>- the actual content of the SoapUI project xml (Required).</em></li>
+    <li><strong>suite</strong> <em>- the suite to run (usually will be TestSuite if left unchanged from SoapUI) (Optional).</em>
+	<li><strong>properties</strong> <em>- File containing global properties. Exported from SOAPui preferences editor (Optional)</em>
+	<li><strong>option</strong> <em>- Text or file containing Testrunner options, e.g. "-r" for short summary. Can point to a file with lines of options (Optional).</em></li>
   </ul>
   <br /><br />
 


### PR DESCRIPTION
Also made suite information optional, as running all tests is default for testrunner.sh and supported.
For backwards compatibility, suite is still supported for POST method